### PR TITLE
Update shabbat-and-holiday-modes.groovy

### DIFF
--- a/smartapps/shabbatholidaymode/shabbat-and-holiday-modes.src/shabbat-and-holiday-modes.groovy
+++ b/smartapps/shabbatholidaymode/shabbat-and-holiday-modes.src/shabbat-and-holiday-modes.groovy
@@ -30,7 +30,7 @@ preferences {
 		input "havdalahOffset", "number", title: "Minutes After Sundown", required:true
 	} 
 	section("Your ZipCode") {
-		input "zipcode", "number", title: "ZipCode", required:true
+		input "zipcode", "text", title: "ZipCode", required:true
 	}
     section( "Notifications" ) {
         input "sendPushMessage", "enum", title: "Send a push notification?", metadata:[values:["Yes","No"]], required:false


### PR DESCRIPTION
Change input from number to text so zip codes that start with 0 don't lose the 0.

Currently with a **number** input the zip code 01101 returns _http://www.hebcal.com/hebcal/?v=1&cfg=json&nh=off&nx=off&year=now&month=now&mf=off&c=on&zip=1101&m=50&s=off&D=off&d=off&o=off&ss=off_ with a number input.

A **text** input yields the correct urlRequest:
http://www.hebcal.com/hebcal/?v=1&cfg=json&nh=off&nx=off&year=now&month=now&mf=off&c=on&zip=01101&m=50&s=off&D=off&d=off&o=off&ss=off


